### PR TITLE
Removed the &nbsp; line which was causing the documentador link on th…

### DIFF
--- a/src/Ubirimi/Documentador/Resources/views/_menu.php
+++ b/src/Ubirimi/Documentador/Resources/views/_menu.php
@@ -71,7 +71,6 @@ $spacesInMenu = UbirimiContainer::get()['repository']->get(Space::class)->getByC
                         style="cursor: pointer;">
                         <span>Documentador</span>
                         <span class="<?php if ($menuSelectedCategory == 'documentador') echo 'arrowSelected'; else echo 'arrow' ?>"></span>
-                        &nbsp;
                     </td>
                     <td>&nbsp;</td>
                     <td align="right">


### PR DESCRIPTION
…e secondary menu to go to 2 lines.

After my fix http://screencast.com/t/HxQvbMqI9Y

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ubirimi/ubirimi/52)
<!-- Reviewable:end -->
